### PR TITLE
Set default argument

### DIFF
--- a/kmr_dataset/io.py
+++ b/kmr_dataset/io.py
@@ -8,7 +8,7 @@ from .install import _check_install
 
 installpath = os.path.abspath(os.path.dirname(__file__))
 
-def _check_size(size, force):
+def _check_size(size, force=False):
     if force:
         return True
     available_size = '2m 5m small'.split()


### PR DESCRIPTION
https://github.com/lovit/kmrd/blob/master/kmr_dataset/io.py#L77-L79
```python
def _prepare_rate_loader(directory, size):
    _check_size(size)
```
But, _check_size function has force argument.

https://github.com/lovit/kmrd/blob/master/kmr_dataset/io.py#L11-L16
```python
def _check_size(size, force):
    if force:
        return True
```

So , I set default value for `force` argument.