### PR TITLE
change np.int to np.int_ to fix attributeError in Numpy>=1.23

### DIFF
--- a/kmr_dataset/io.py
+++ b/kmr_dataset/io.py
@@ -141,7 +141,7 @@ def load_rates(directory=None, size='small'):
             raise ValueError(f'There unexpected error in data {path}')
 
     rates = csr_matrix((data, (rows, cols)))
-    timestamps = np.array(timestamps, dtype=np.int)
+    timestamps = np.array(timestamps, dtype=np.int_)
     return rates, timestamps
 
 def load_histories(directory=None, size='small'):


### PR DESCRIPTION
Since Numpy's 1.20 update, numpy.int has been deprecated, and since 1.24 it has been removed.

In later versions, using numpy.int as-is raises an AttributeError, so I've modified the data type accordingly.